### PR TITLE
Catch ECONNRESET

### DIFF
--- a/bluelet.py
+++ b/bluelet.py
@@ -349,6 +349,10 @@ def run(root_coro):
                             exc.args[0] == errno.EPIPE:
                         # Broken pipe. Remote host disconnected.
                         pass
+                    elif isinstance(exc.args, tuple) and \
+                            exc.args[0] == errno.ECONNRESET:
+                        # Connection was reset by peer.
+                        pass
                     else:
                         traceback.print_exc()
                     # Abort the coroutine.


### PR DESCRIPTION
If the other end of the socket hangs up abruptly we get a "connection reset by peer" exception, also known as ECONNRESET (104) in errno terms. In Python 2 this is mapped to a `socket.error` and in Python 3 this is  `ConnectionResetError` which is thankfully a subclass of the  `socket.error` exception class.

This is a port of a a commit against the embedded copy of bluelet in beets, extracted from beetbox/beets#3214.